### PR TITLE
fix: missing language resource causes crash. defaults to english

### DIFF
--- a/src/yass/I18.java
+++ b/src/yass/I18.java
@@ -26,6 +26,7 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Locale;
+import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
 /**
@@ -84,7 +85,13 @@ public class I18 {
                 e.printStackTrace();
             }
         } else {
-            bundle = ResourceBundle.getBundle("yass.resources.i18.yass", loc);
+            try {
+                bundle = ResourceBundle.getBundle("yass.resources.i18.yass", loc);
+            } catch (MissingResourceException e) {
+                // language is missing
+                System.out.println("Failed to load " + lang + ", default to english.");
+                bundle = ResourceBundle.getBundle("yass.resources.i18.yass", new Locale("en"));
+            }
         }
     }
 


### PR DESCRIPTION
I'm on ko-KR Windows 11 and the released 2.4.2 exe did not work for me, so I checked the reason.

Since korean is missing in the resources directory, when the app launches by first time it makes exception and does not launch.

Simply added exception handling, defaulting language to english.